### PR TITLE
fix: pass `K` type argument to `LoadFn`

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,6 @@
 export type LoadFn<T, K = string> = (keys: K[]) => Promise<(T | Error)[]>;
 
-export function load<T, K = string>(loadFn: LoadFn<T>, key: K): Promise<T>;
+export function load<T, K = string>(loadFn: LoadFn<T, K>, key: K): Promise<T>;
 
 export function factory<T, K = string>(
 	loadFn: LoadFn<T, K>,


### PR DESCRIPTION
<!-- what are you solving here -->

---

Pass the missing `K` type argument to `LoadFn`. It will be the resolve type error encountered when trying to use the loader function that does not take a not non-string argument.

#### Linked issues

- N/A

fixes: N/A